### PR TITLE
Ensured that original buffer is initialized in test_decompression

### DIFF
--- a/lz4a/src/lib.rs
+++ b/lz4a/src/lib.rs
@@ -192,7 +192,7 @@ mod test {
             let mut orig: Vec<u8> = Vec::with_capacity(*sz);
             unsafe {
                 orig.set_len(*sz);
-
+                orig.fill(0);
                 {
                     //it's sort of randomized data
                     orig[0] = 1;


### PR DESCRIPTION
We've been prototyping a version of Miri that can execute foreign functions. It found a bug in the test case `test_decompression`. 

THe buffer `orig` is only partially initialized
```
let mut orig: Vec<u8> = Vec::with_capacity(*sz);
unsafe {
    orig.set_len(*sz);
    {
        //it's sort of randomized data
        orig[0] = 1;
        orig[*sz / 4] = 4;
        orig[*sz / 2] = 7;
        orig[*sz * 2 / 3] = 10;
        orig[*sz - 1] = 1;
    }
```
Later, its contents is compared against another buffer using `assert_eq!`
```
assert_eq!(&orig[0..*sz], &buf[0..cz]);
```
This uses the intrinsic [`compare_bytes`](https://doc.rust-lang.org/std/intrinsics/fn.compare_bytes.html), which requires both slices to be fully initialized. 

Commit b45549d fixes this by zero-initializing the buffer `orig` using `orig.fill(0)`.